### PR TITLE
explicitly build with cairo support

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -1,7 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
+cairo:
+- '1'
 cdt_name:
 - cos6
 channel_sources:
@@ -11,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -3,7 +3,9 @@ BUILD:
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
+cairo:
+- '1'
 cdt_arch:
 - aarch64
 cdt_name:
@@ -15,7 +17,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -1,7 +1,9 @@
 c_compiler:
 - gcc
 c_compiler_version:
-- '11'
+- '12'
+cairo:
+- '1'
 cdt_name:
 - cos7
 channel_sources:
@@ -11,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - gxx
 cxx_compiler_version:
-- '11'
+- '12'
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 gmp:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -5,7 +5,9 @@ MACOSX_SDK_VERSION:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
+cairo:
+- '1'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -13,7 +15,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 gmp:
 - '6'
 jpeg:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -3,7 +3,9 @@ MACOSX_DEPLOYMENT_TARGET:
 c_compiler:
 - clang
 c_compiler_version:
-- '14'
+- '15'
+cairo:
+- '1'
 channel_sources:
 - conda-forge
 channel_targets:
@@ -11,7 +13,7 @@ channel_targets:
 cxx_compiler:
 - clangxx
 cxx_compiler_version:
-- '14'
+- '15'
 gmp:
 - '6'
 jpeg:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -1,5 +1,7 @@
 c_compiler:
 - vs2019
+cairo:
+- '1'
 channel_sources:
 - conda-forge
 channel_targets:

--- a/recipe/bld_gmsh.bat
+++ b/recipe/bld_gmsh.bat
@@ -18,6 +18,7 @@ cmake -G "NMake Makefiles" ^
       -D BLAS_LAPACK_LIBRARIES=%LIBRARY_PREFIX%\lib\lapack.lib;%LIBRARY_PREFIX%\lib\blas.lib ^
       -D GMSH_RELEASE=1 ^
       -D ENABLE_OPENMP=0 ^
+      -D ENABLE_CAIRO=1 ^
       %SRC_DIR%
 if errorlevel 1 exit 1
 

--- a/recipe/build_gmsh.sh
+++ b/recipe/build_gmsh.sh
@@ -24,6 +24,7 @@ cmake ${CMAKE_ARGS} \
     -DBLAS_LAPACK_LIBRARIES="$PREFIX/lib/libblas${SHLIB_EXT};$PREFIX/lib/liblapack${SHLIB_EXT}" \
     -DGMSH_RELEASE=1 \
     -DENABLE_TOUCHBAR=OFF \
+    -DENABLE_CAIRO=ON \
     ..
 
 make -j${CPU_COUNT}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/disable_wmain.patch
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: gmsh
@@ -52,6 +52,7 @@ outputs:
         - xorg-libxrender    # [linux]
         - xorg-libx11        # [linux]
         - xorg-libxmu        # [linux]
+        - cairo
 
       run:
         - gmp  # [not win]


### PR DESCRIPTION
Fixes #74.

Seems that the Linux docker image has cairo installed and so cairo support gets enabled automatically in the gmsh build. If installing the resulting package on a system without cairo installed, gmsh will fail to run since it can't find cairo.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
