### PR TITLE
revert exact_pin in python-gmsh

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - patches/disable_wmain.patch
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: gmsh
@@ -81,7 +81,7 @@ outputs:
     script: install_python.bat  # [win]
     requirements:
       run:
-        - {{ pin_subpackage("gmsh", exact=True) }}
+        - {{ pin_subpackage("gmsh", max_pin="x.x.x") }}
         - numpy
         - python
     test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -81,6 +81,8 @@ outputs:
     script: install_python.bat  # [win]
     requirements:
       run:
+        # this should pin build number as well,
+        # but we can't use exact=True while this is noarch
         - {{ pin_subpackage("gmsh", max_pin="x.x.x") }}
         - numpy
         - python


### PR DESCRIPTION
reverts exact_pin change from #92 